### PR TITLE
Implement multi-JDK CI build strategy

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -8,10 +8,33 @@ on:
     types: [opened, synchronize, reopened]
 
 jobs:
-  build:
+  test-java21:
+    name: Test Core Library (Java 21)
     runs-on: ubuntu-latest
-    name: Build with JDK 24
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
+      with:
+        java-version: '21'
+        distribution: 'oracle'
+    
+    - name: Cache Maven dependencies
+      uses: actions/cache@v4
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-java21-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2-java21
+    
+    - name: Test core library (Java 21)
+      run: mvn clean test -pl json-java21
 
+  test-java24:
+    name: Test with Tooling (Java 24)
+    runs-on: ubuntu-latest
+    
     steps:
     - uses: actions/checkout@v4
     
@@ -25,11 +48,8 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ~/.m2
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-m2
+        key: ${{ runner.os }}-m2-java24-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2-java24
     
-    - name: Build with Maven
-      run: mvn clean compile
-    
-    - name: Package JAR
-      run: mvn package
+    - name: Test full project (Java 24)
+      run: mvn clean test


### PR DESCRIPTION
Implements multi-job CI build to validate both Java 21 core compatibility and Java 24 tooling requirements.

✅ Core library builds on Java 21 (maintains compatibility promise)
✅ Full project builds on Java 24 (enables tooling features)

Closes #9