### PR TITLE
Fix POM Project URL and SCM for Central links

### DIFF
--- a/json-compatibility-suite/pom.xml
+++ b/json-compatibility-suite/pom.xml
@@ -14,6 +14,13 @@
     <packaging>jar</packaging>
 
     <name>java.util.json Java21 Backport – JSON Test Suite</name>
+    <url>https://simbo1905.github.io/java.util.json.Java21/</url>
+    <scm>
+        <connection>scm:git:https://github.com/simbo1905/java.util.json.Java21.git</connection>
+        <developerConnection>scm:git:git@github.com:simbo1905/java.util.json.Java21.git</developerConnection>
+        <url>https://github.com/simbo1905/java.util.json.Java21</url>
+        <tag>HEAD</tag>
+    </scm>
     <description>Runs the official JSON Test Suite against the java.util.json Java 21 backport to track conformance with JSON standards.</description>
 
     <dependencies>

--- a/json-java21-api-tracker/pom.xml
+++ b/json-java21-api-tracker/pom.xml
@@ -14,6 +14,13 @@
     <packaging>jar</packaging>
 
     <name>java.util.json Java21 Backport Upstream API Tracker</name>
+    <url>https://simbo1905.github.io/java.util.json.Java21/</url>
+    <scm>
+        <connection>scm:git:https://github.com/simbo1905/java.util.json.Java21.git</connection>
+        <developerConnection>scm:git:git@github.com:simbo1905/java.util.json.Java21.git</developerConnection>
+        <url>https://github.com/simbo1905/java.util.json.Java21</url>
+        <tag>HEAD</tag>
+    </scm>
     <description>Compares the OpenJDK sandbox java.util.json API to this Java 21 backport and reports differences to track upstream changes. Experimental tooling.</description>
 
     <properties>

--- a/json-java21-schema/pom.xml
+++ b/json-java21-schema/pom.xml
@@ -14,6 +14,13 @@
     <artifactId>java.util.json.schema</artifactId>
     <packaging>jar</packaging>
     <name>java.util.json Java21 Backport – JSON Schema Validator (2020-12)</name>
+    <url>https://simbo1905.github.io/java.util.json.Java21/</url>
+    <scm>
+        <connection>scm:git:https://github.com/simbo1905/java.util.json.Java21.git</connection>
+        <developerConnection>scm:git:git@github.com:simbo1905/java.util.json.Java21.git</developerConnection>
+        <url>https://github.com/simbo1905/java.util.json.Java21</url>
+        <tag>HEAD</tag>
+    </scm>
     <description>Experimental JSON Schema 2020-12 validator built using the java.util.json Java 21 backport; includes integration tests running the official JSON Schema Test Suite.</description>
 
     <properties>

--- a/json-java21/pom.xml
+++ b/json-java21/pom.xml
@@ -14,6 +14,13 @@
     <packaging>jar</packaging>
 
     <name>java.util.json Java21 Backport</name>
+    <url>https://simbo1905.github.io/java.util.json.Java21/</url>
+    <scm>
+        <connection>scm:git:https://github.com/simbo1905/java.util.json.Java21.git</connection>
+        <developerConnection>scm:git:git@github.com:simbo1905/java.util.json.Java21.git</developerConnection>
+        <url>https://github.com/simbo1905/java.util.json.Java21</url>
+        <tag>HEAD</tag>
+    </scm>
     <description>Backport of the OpenJDK sandbox java.util.json API adapted for Java 21+. Experimental; APIs and behavior may change as upstream evolves.</description>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -30,9 +30,10 @@
     </developers>
 
     <scm>
-        <connection>scm:git:git://github.com/simbo1905/java.util.json.Java21.git</connection>
-        <developerConnection>scm:git:ssh://github.com:simbo1905/java.util.json.Java21.git</developerConnection>
-        <url>https://github.com/simbo1905/java.util.json.Java21/tree/main</url>
+        <connection>scm:git:https://github.com/simbo1905/java.util.json.Java21.git</connection>
+        <developerConnection>scm:git:git@github.com:simbo1905/java.util.json.Java21.git</developerConnection>
+        <url>https://github.com/simbo1905/java.util.json.Java21</url>
+        <tag>HEAD</tag>
     </scm>
 
     <modules>


### PR DESCRIPTION
Closes #25

What
- Parent POM: set <scm> to root repo URLs (HTTPS + SSH) and <url> remains the site root; add <tag>HEAD</tag>.
- Modules (java.util.json, json-java21-api-tracker, json-compatibility-suite, java.util.json.schema): add <url> to site root and override <scm> to root repo URLs to avoid Central appending artifact paths.

Notes
- No build or behavior changes; metadata only.