### PR TITLE
Issue #59 Fix visibility mismatch in Utils.getPath method signature

### DIFF
--- a/json-java21/src/main/java/jdk/sandbox/internal/util/json/Utils.java
+++ b/json-java21/src/main/java/jdk/sandbox/internal/util/json/Utils.java
@@ -113,7 +113,7 @@ public class Utils {
                 + ((jv instanceof JsonValueImpl jvi && jvi.doc() != null) ? JsonPath.getPath(jvi) : ""));
     }
 
-    public static String getPath(JsonValueImpl jvi) {
+    static String getPath(JsonValueImpl jvi) {
         return JsonPath.getPath(jvi);
     }
 


### PR DESCRIPTION
Fixes visibility mismatch in Utils.getPath method by changing method visibility from public to package-private.

Problem: The method was declared public but used a package-private parameter type (JsonValueImpl), making it effectively unusable from outside the package.

Solution: Changed method visibility to package-private to match the parameter type visibility, ensuring proper encapsulation while maintaining internal functionality.

Changes:
- Changed  to 
- Maintains all existing functionality for internal package usage
- Resolves visibility mismatch identified by static analysis

Testing:
- Code compiles successfully
- All tests pass (25 tests, 0 failures)

Closes #59