### PR TITLE
JTD codegen build actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,8 @@ jobs:
                       for k in totals: totals[k]+=int(r.get(k,'0'))
                   except Exception:
                       pass
-          exp_tests=850
-          exp_skipped=2
+          exp_tests=1354
+          exp_skipped=0
           if totals['tests']!=exp_tests or totals['skipped']!=exp_skipped:
               print(f"Unexpected test totals: {totals} != expected tests={exp_tests}, skipped={exp_skipped}")
               sys.exit(1)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up JDK 21
+      - name: Set up JDK 24
         uses: actions/setup-java@v4
         with:
-          distribution: temurin
-          java-version: '21'
+          distribution: oracle
+          java-version: '24'
           cache: 'maven'
 
       - name: Build and verify
@@ -39,8 +39,8 @@ jobs:
                       for k in totals: totals[k]+=int(r.get(k,'0'))
                   except Exception:
                       pass
-          exp_tests=611
-          exp_skipped=0
+          exp_tests=850
+          exp_skipped=2
           if totals['tests']!=exp_tests or totals['skipped']!=exp_skipped:
               print(f"Unexpected test totals: {totals} != expected tests={exp_tests}, skipped={exp_skipped}")
               sys.exit(1)


### PR DESCRIPTION
---
## What changed

- Updated `.github/workflows/ci.yml` to use Java 24 (from 21) with the `oracle` distribution (from `temurin`).
- Adjusted the expected test count in the CI workflow from 611 to 1354.

## Why this change is needed

- The `json-java21-jtd-codegen` module, introduced in PR #139, requires Java 24+ (specifically for the ClassFile API - JEP 484). The previous Java 21 setup caused build failures with a "release version 24 not supported" error.
- The expected test count was updated to reflect the actual number of tests after the new codegen module was integrated, resolving a failing test assertion.

## How were these changes tested

- The changes were tested by running the GitHub Actions workflow. Verification was performed by confirming that all build checks on PR #139 are now passing.

## Checklist

- [x] Code builds / passes tests
- [ ] New tests added if needed
- [ ] Update to use `CODING_STYLE_LLM.md` convensions
- [ ] Documentation updated if needed
- [ ] `AGENTS.md` updated if appropriate

---
<p><a href="https://cursor.com/background-agent?bcId=bc-b84f29c5-e7b8-4f90-96f2-62ccc39d6cda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b84f29c5-e7b8-4f90-96f2-62ccc39d6cda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

